### PR TITLE
#163372808 Fix UI admin Delete party message

### DIFF
--- a/UI/admin/addparties.html
+++ b/UI/admin/addparties.html
@@ -133,7 +133,6 @@
                                         <input type="text" placeholder="party name">
                                 <input type="text" placeholder="HQ address">
                                     <input type="file">
-                                    <!-- <input type="text" placholder="party name"> -->
                                     <br>
                                     <input type="submit" onclick="closeEdit()">
                                 </form>
@@ -141,7 +140,7 @@
 
                             <!-- delete party -->
                             <div class="modal2" id="deleteparty">
-                                                <h1>Data will be lost!</h1>
+                                                <h1>This party will be deleted</h1>
                                             <button onclick="closeDelete()">Cancel</button>
                                             <button>Go on</button>
                                     </div>


### PR DESCRIPTION
## What does this PR do?
Add ability for admins to really understand delete political party modal message

## Description of Task to be completed?
Political party modal message should be clear

## Any background context you want to provide?
To delete political party, as an admin use the delete button.

## Screenshots
![admin](https://user-images.githubusercontent.com/37017788/51637241-0d9f6b00-1f10-11e9-8919-12984de98bff.PNG)


## What are the relevant pivotal tracker stories?
#163372808

## Any other relevant message?
Later, gh-pages will be updated with the latest UI changes on develop branch