### PR TITLE
 #163502040:Add modal to 'run' button

### DIFF
--- a/UI/politician/politician.html
+++ b/UI/politician/politician.html
@@ -37,33 +37,55 @@
                         <img class="img" src="../images/presidentimg.png">
                         <p class="people">President</p>
                         <br>
-                        <button class="vote">Run</button>
+                        <!-- <button  href="#modalwindow" class="open-modal">Run</button> -->
+                        <button id="modalbtn" class="button">Run</button>
                 </div>
                 <div class="box box2">
                                 <img class="img" src="../images/governor.png">
                                 <p class="people">Governor of<br> Lagos</p>
-                                <button class="vote">Run</button>
+                                <button id="modalbtn" class="button">Run</button>
                 </div>
                 <div class="box box2">
                     <img class="img" src="../images/governor.png">
                     <p class="people">Governor of<br> Port-Harcourt</p>
-                    <button class="vote">Run</button>
+                    <button id="modalbtn" class="button">Run</button>
     </div>
     <div class="box box2">
         <img class="img" src="../images/senateimg.png">
         <p class="people">Senate<br> President</p>
-        <button class="vote">Run</button>
+        <button id="modalbtn" class="button">Run</button>
 </div>
 <div class="box box2">
     <img class="img" src="../images/governor.png">
     <p class="people">Governor of<br> Anambra</p>
-    <button class="vote">Run</button>
+    <button id="modalbtn" class="button">Run</button>
 </div>
 <div class="box box2">
     <img class="img" src="../images/governor.png">
     <p class="people">Governor of<br> Imo</p>
-    <button class="vote">Run</button>
+    <button id="modalbtn" class="button">Run</button>
 </div>
+
+
+
+
+<div id="simplemodal" class="modal">
+    <div class="content">
+        <!--  When a text is hooked in a <span> element, you can style it with CSS, or manipulate it with JavaScript. -->
+        <!-- &times means a multiplication sign -->
+        <span class="closebtn" id="cancelIcon">&times;</span>  
+
+        <p>Are you sure?</p>
+        <button class="button" id="cancelbtn">Cancel</button>
+        <button class="button">Yes</button>
+    </div>
+
+    </div>
+</div>
+
+
+
+
         </div>
             <script src="../scripts/politician.js"></script>
 </body>

--- a/UI/scripts/politician.js
+++ b/UI/scripts/politician.js
@@ -5,3 +5,45 @@ function openNav() {
 function closeNav() {
     document.getElementById("mySidenav").style.width = "0";
 }
+
+
+
+
+
+// hhhhh
+//get modal element
+let modal = document.getElementById("simplemodal");
+//open modal by clicking button
+let modalbtn = document.getElementById("modalbtn");
+//close button
+let closebtn = document.getElementsByClassName("closebtn") [0]; //0 indicates first class 
+
+modalbtn.addEventListener('click', openModal); // to open modal window
+closebtn.addEventListener('click', closeModal); // to close modal window by clicking close button
+window.addEventListener('click', outsideClick); // to close modal window by clicking outside the modal window
+
+function openModal()
+{
+    modal.style.display = "block";
+}
+
+function closeModal()
+{
+    modal.style.display = "none";
+}
+
+function outsideClick(e)
+{
+    if(e.target == modal)
+    {
+        modal.style.display = "none";
+    }
+}
+
+let cancelbtn = document.getElementById("cancelbtn");
+let cancelIcon = document.getElementById("cancelIcon");
+cancelbtn.addEventListener('click', closemodal);
+cancelIcon.addEventListener('click', closemodal);
+function closemodal(){
+    modal.style.display = 'none';
+}

--- a/UI/styles/politician.css
+++ b/UI/styles/politician.css
@@ -186,8 +186,99 @@ body{
 
     }
 
-    @media screen and (max-width: 768px){
-        .nav ul li a {
-            display:none;
-        }
+   
+
+
+/* 
+    .text-center{
+        text-align: center;
     }
+    .custom-modal{
+        z-index: 3;
+        display
+    } */
+
+
+
+
+
+    /* old */
+    .button{
+    background-color:#ffffff;
+    color:rgb(10, 65, 86);
+    padding: 6px 32px;
+    border: 0;
+    font-weight:bold;
+}
+
+.button:hover
+{
+    background-color: rgb(10, 65, 86);
+    color: #ffffff;
+}
+
+.modal
+{
+    display: none;
+    position: fixed;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0.10, 0.4, 0.4);
+}
+
+.content
+{
+    background-color: #ffffff;
+    margin: 20% auto;
+    width: 40%;
+    height: 150px;
+    padding: 12px;
+    animation-name: modalopen;
+    animation-duration: 1s;
+}
+.content p{
+ font-weight: bold;
+ font-size: 5vh;
+}
+.content button{
+    
+    font-weight: bold;
+    font-size: 2vh;
+   }
+
+.closebtn
+{
+    color: gray;
+    float: right;
+    font-size: 30px;
+}
+
+.closebtn:hover , .closebtn:focus
+{
+    color: red;
+    cursor: pointer;
+}
+
+@keyframes modalopen
+{
+    from { opacity: 0 }
+    to { opacity: 1 }
+}
+
+@media screen and (max-width: 768px){
+    .nav ul li a {
+        display:none;
+    }
+    
+    .content{
+background-color: #ffffff;
+margin: 60% auto;
+width: 90%;
+height: 190px;
+}
+
+}

--- a/UI/styles/politician.css
+++ b/UI/styles/politician.css
@@ -227,7 +227,7 @@ body{
     height: 100%;
     width: 100%;
     overflow: auto;
-    background-color: rgba(0, 0.10, 0.4, 0.4);
+    background-color: rgba(0, 0.10, 0.4, 0.9);
 }
 
 .content
@@ -243,6 +243,7 @@ body{
 .content p{
  font-weight: bold;
  font-size: 5vh;
+ color:rgb(10, 65, 86);
 }
 .content button{
     


### PR DESCRIPTION
## What does this PR do?
Add ability for a politician to see the difference between the modal and the background

## Description of Task to be completed?
The background should fade in when modal opens

## Screenshots
![before-run-modal](https://user-images.githubusercontent.com/37017788/51820702-80e80a80-228b-11e9-9678-12f5317c4fdc.PNG)
![admin-run](https://user-images.githubusercontent.com/37017788/51833273-d6341400-22ab-11e9-9095-0dfd3723c132.PNG)
![run-btn-mobile](https://user-images.githubusercontent.com/37017788/51833427-42af1300-22ac-11e9-8f9b-979da3ff2eda.PNG)
![run-button](https://user-images.githubusercontent.com/37017788/51833531-915cad00-22ac-11e9-9b62-162cca0129ca.PNG)




## What are the relevant pivotal tracker stories?
#163502040